### PR TITLE
build(docs): Update make_docs script for generating Sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,5 @@ dmypy.json
 .pytype/
 cython_debug/
 .idea
-.idea/!/NotKinoPoiskAPI/Data/Cache/
-NotKinoPoiskAPI/Data/Cache/
+.idea/!/NotKinoPoiskAPI/Data/**/
+NotKinoPoiskAPI/Data/**/

--- a/NotKinoPoiskAPI/Controller/CacheController.py
+++ b/NotKinoPoiskAPI/Controller/CacheController.py
@@ -4,36 +4,81 @@ import os
 import pickle
 import platform
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from decouple import config
 
 
 class CacheController:
+	"""
+	Класс по управлению за кешем.
+
+	:param Path cache_path: Путь до папки с кешем
+	:param int cache_lifetime: Время жизни кеша
+	"""
 	cache_path: Path
+	"""Путь до папки с кешем"""
 	cache_lifetime: int
+	"""Время жизни кеша"""
 
 	def __init__(self, cache_path: Optional[Union[Path, str]] = None, lifetime: int = 7):
+		"""
+		Инициализация кеша
+
+		:param Union[Path, str] cache_path: Путь до папки с кешем
+		:param int lifetime: Время жизни кеша
+		"""
 		if cache_path is None:
 			ROOT = Path(__file__).parent.parent
 			cache_path = config('NKPA_CACHE_DIR', cast=str, default=ROOT / 'Data/Cache')
-		self._set_cache_path(cache_path)
+		self.set_cache_path(cache_path)
 		self.cache_lifetime = config('NKPA_CACHE_LIFE', cast=int, default=lifetime)
 
-	def _set_cache_path(self, path):
-		self.cache_path = Path(path)
+	def set_cache_path(self, path: Union[Path, str]):
+		"""
+		Установка пути до папки с кешем
+		Создаёт папки на пути
+
+		:param Union[Path, str] path: Путь до папки с кешем
+		"""
+		self.cache_path = Path(path) if isinstance(path, str) else path
 		self.cache_path.mkdir(parents=True, exist_ok=True)
 
-	def get_cache_file(self, data):
-		data_hash = hashlib.md5(data.encode(encoding='UTF-8')).hexdigest()
+	def get_cache_file(self, file_name: str):
+		"""
+		Получить путь до файла с кешем
+
+		:param str file_name: Данные для хэширования
+
+		:return: Путь до файла с кешем
+
+		:rtype: str
+		"""
+		data_hash = hashlib.md5(file_name.encode(encoding='UTF-8')).hexdigest()
 		return self.cache_path / f'{data_hash.__str__()}.pickle'
 
-	def set_cache(self, name, data):
+	def set_cache(self, name: str, data: Any):
+		"""
+		Запись в кеш
+
+		:param str name: Имя кеша
+		:param Any data: Данные для кеша
+		"""
 		cache_file = self.get_cache_file(name)
 		with open(cache_file, 'wb') as f:
 			pickle.dump(data, f)
 
-	def get_cache(self, name):
+	def get_cache(self, name:str):
+		"""
+		Получить данные из кеша
+		Если кеш не существует или время жизни кеша истекло, то возвращает None
+
+		:param str name: Имя кеша
+
+		:return: Данные из кеша, либо None (если данные отсутствуют или устарели)
+
+		:rtype: dict | None
+        """
 		cache_file = self.get_cache_file(name)
 		if Path(cache_file).exists():
 			file_created = datetime.datetime.fromtimestamp(CacheController.creation_date(cache_file))
@@ -52,9 +97,15 @@ class CacheController:
 	@staticmethod
 	def creation_date(path_to_file):
 		"""
-		Try to get the date that a file was created, falling back to when it was
-		last modified if that isn't possible.
-		See http://stackoverflow.com/a/39501288/1709587 for explanation.
+		Возвращает дату создания файла
+
+		:ref: https://stackoverflow.com/a/39501288/1709587
+
+		:param str path_to_file: Путь до файла
+
+		:return: Дата создания файла
+
+		:rtype: float
 		"""
 		if platform.system() == 'Windows':
 			return os.path.getctime(path_to_file)

--- a/NotKinoPoiskAPI/Controller/Connector.py
+++ b/NotKinoPoiskAPI/Controller/Connector.py
@@ -14,14 +14,16 @@ from NotKinoPoiskAPI.Errors.ApiError import ApiError
 class Connector:
 	"""
 	Класс для подключения к API.
-	:param proxy: Прокси для подключения.
-	:param session: Сессия для запросов.
-	:param user_agent: User-Agent для запросов.
-	:param headers: Дополнительные заголовки.
-	:param method: Метод запроса.
-	:param timeout: Время ожидания ответа.
+
+	:param str api_key: API-Key для подключения.
+	:param ProxyController proxy: Прокси для подключения.
+	:param Session session: Сессия для запросов.
+	:param str user_agent: User-Agent для запросов.
+	:param dict headers: Дополнительные заголовки.
+	:param int timeout: Время ожидания ответа.
 	"""
 	api_key: str
+	"""API-Key для подключения"""
 	proxy: Optional[ProxyController]
 	session: Optional[Session]
 	user_agent: Optional[str]
@@ -80,11 +82,16 @@ class Connector:
 	def send(self, url: str, params: dict = None, data: dict = None, json: dict = None, method: str = 'GET'):
 		"""
 		Отправка запроса.
-		:param url: URL запроса.
-		:param params: Параметры запроса.
-		:param data: Данные запроса.
-		:param json: JSON данные запроса.
-		:param method: Метод запроса.
+
+		:param str url: URL запроса.
+		:param dict params: Параметры запроса.
+		:param dict data: Данные запроса.
+		:param dict json: JSON данные запроса.
+		:param str method: Метод запроса.
+
+		:return: Возвращает JSON объект в случае удачи. При ошибке выбрасывает её и останавливает скрипт
+
+		:rtype: dict
 		"""
 
 		try:

--- a/NotKinoPoiskAPI/Controller/Films.py
+++ b/NotKinoPoiskAPI/Controller/Films.py
@@ -49,7 +49,7 @@ class KpFilms(NKPA):
 		Данный эндпоинт возвращает базовые данные о фильме. Поле lastSync показывает дату последнего обновления данных.
 		/api/v2.2/films/{id}
 		:param film_id: ID фильма.
-		:return Film
+		:return: Film
 		"""
 		return ObjectController.json_to_object(self.get_data(self.get_api_url(f'films/{film_id}')), Film)
 
@@ -68,7 +68,7 @@ class KpFilms(NKPA):
 		Данный эндпоинт возвращает список фактов и ошибок в фильме.
 		/api/v2.2/films/{id}/facts
 		:param film_id: ID фильма.
-		:return FactResponse
+		:return: FactResponse
 		"""
 		return ObjectController.json_to_object(self.get_data(self.get_api_url(f'films/{film_id}/facts')), FactResponse)
 
@@ -77,7 +77,7 @@ class KpFilms(NKPA):
 		Данный эндпоинт возвращает данные о прокате в разных странах.
 		/api/v2.2/films/{id}/distributions
 		:param film_id: ID фильма.
-		:return DistributionResponse
+		:return: DistributionResponse
 		"""
 		return ObjectController.json_to_object(self.get_data(self.get_api_url(f'films/{film_id}/distributions')),
 		                                       DistributionResponse)
@@ -97,7 +97,7 @@ class KpFilms(NKPA):
 		Данный эндпоинт возвращает данные о наградах и премиях фильма.
 		/api/v2.2/films/{id}/awards
 		:param film_id: ID фильма.
-		:return AwardResponse
+		:return: AwardResponse
 		"""
 		return ObjectController.json_to_object(self.get_data(self.get_api_url(f'films/{film_id}/awards')),
 		                                       AwardResponse)
@@ -114,7 +114,7 @@ class KpFilms(NKPA):
 		<iframe is="x-frame-bypass" src="https://widgets.kinopoisk.ru/discovery/trailer/167560?onlyPlayer=1&autoplay=1&cover=1" width="500" height="500"></iframe>
 		/api/v2.2/films/{id}/videos
 		:param film_id: ID фильма.
-		:return VideoResponse
+		:return: VideoResponse
 		"""
 		return ObjectController.json_to_object(self.get_data(self.get_api_url(f'films/{film_id}/videos')),
 		                                       VideoResponse)
@@ -124,7 +124,7 @@ class KpFilms(NKPA):
 		Данный эндпоинт возвращает похожие фильмы.
 		/api/v2.2/films/{id}/similars
 		:param film_id: ID фильма.
-		:return RelatedFilmResponse
+		:return: RelatedFilmResponse
 		"""
 		return ObjectController.json_to_object(self.get_data(self.get_api_url(f'films/{film_id}/similars')),
 		                                       RelatedFilmResponse)
@@ -147,7 +147,7 @@ class KpFilms(NKPA):
 		:param film_id: ID фильма.
 		:param image_type: Тип изображения.
 		:param page: Номер страницы.
-		:return ImageResponse
+		:return: ImageResponse
 		"""
 		return ObjectController.json_to_object(
 				self.get_data(self.get_api_url(f'films/{film_id}/images', type=image_type.name, page=page)),
@@ -160,7 +160,7 @@ class KpFilms(NKPA):
 		:param film_id: ID фильма.
 		:param page: Номер страницы.
 		:param order: Сортировка.
-		:return ReviewResponse
+		:return: ReviewResponse
 		"""
 		return ObjectController.json_to_object(
 				self.get_data(self.get_api_url(f'films/{film_id}/reviews', page=page, order=order.name)),
@@ -172,7 +172,7 @@ class KpFilms(NKPA):
 		/api/v2.2/films/{id}/external_sources
 		:param film_id: ID фильма.
 		:param page: Номер страницы.
-		:return ExternalSourceResponse
+		:return: ExternalSourceResponse
 		"""
 		return ObjectController.json_to_object(
 				self.get_data(self.get_api_url(f'films/{film_id}/external_sources', page=page)), ExternalSourceResponse)

--- a/docs/source/NotKinoPoiskAPI.Controller.rst
+++ b/docs/source/NotKinoPoiskAPI.Controller.rst
@@ -1,0 +1,85 @@
+NotKinoPoiskAPI.Controller package
+==================================
+
+Submodules
+----------
+
+NotKinoPoiskAPI.Controller.CacheController module
+-------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.CacheController
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.Connector module
+-------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.Connector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.Films module
+---------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.Films
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.KpUser module
+----------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.KpUser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.Media module
+---------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.Media
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.NKPA module
+--------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.NKPA
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.ObjectController module
+--------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.ObjectController
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.ProxyController module
+-------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.ProxyController
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Controller.Staff module
+---------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Controller.Staff
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: NotKinoPoiskAPI.Controller
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/NotKinoPoiskAPI.Data.rst
+++ b/docs/source/NotKinoPoiskAPI.Data.rst
@@ -1,0 +1,10 @@
+NotKinoPoiskAPI.Data package
+============================
+
+Module contents
+---------------
+
+.. automodule:: NotKinoPoiskAPI.Data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/NotKinoPoiskAPI.Enums.rst
+++ b/docs/source/NotKinoPoiskAPI.Enums.rst
@@ -1,0 +1,149 @@
+NotKinoPoiskAPI.Enums package
+=============================
+
+Submodules
+----------
+
+NotKinoPoiskAPI.Enums.ApiAccountType module
+-------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.ApiAccountType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.CollectionType module
+-------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.CollectionType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.DistributionSubType module
+------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.DistributionSubType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.DistributionType module
+---------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.DistributionType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.FactType module
+-------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.FactType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.FilmsFilterOrder module
+---------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.FilmsFilterOrder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.ImageType module
+--------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.ImageType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.MovieType module
+--------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.MovieType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.PremiereMonth module
+------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.PremiereMonth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.ProductionStatus module
+---------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.ProductionStatus
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.Profession module
+---------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.Profession
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.ProxyType module
+--------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.ProxyType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.RelationType module
+-----------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.RelationType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.ReviewOrder module
+----------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.ReviewOrder
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.ReviewType module
+---------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.ReviewType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.Sex module
+--------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.Sex
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Enums.VideoResponseItemSite module
+--------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Enums.VideoResponseItemSite
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: NotKinoPoiskAPI.Enums
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/NotKinoPoiskAPI.Errors.rst
+++ b/docs/source/NotKinoPoiskAPI.Errors.rst
@@ -1,0 +1,21 @@
+NotKinoPoiskAPI.Errors package
+==============================
+
+Submodules
+----------
+
+NotKinoPoiskAPI.Errors.ApiError module
+--------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Errors.ApiError
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: NotKinoPoiskAPI.Errors
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/NotKinoPoiskAPI.Responses.rst
+++ b/docs/source/NotKinoPoiskAPI.Responses.rst
@@ -1,0 +1,221 @@
+NotKinoPoiskAPI.Responses package
+=================================
+
+Submodules
+----------
+
+NotKinoPoiskAPI.Responses.ApiKeyResponse module
+-----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.ApiKeyResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.AwardResponse module
+----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.AwardResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.BoxOfficeResponse module
+--------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.BoxOfficeResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.DigitalReleaseResponse module
+-------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.DigitalReleaseResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.DistributionResponse module
+-----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.DistributionResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.ExternalSourceResponse module
+-------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.ExternalSourceResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.FactResponse module
+---------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.FactResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.FilmCollectionResponse module
+-------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.FilmCollectionResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.FilmSearchByFiltersResponse module
+------------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.FilmSearchByFiltersResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.FilmSearchResponse module
+---------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.FilmSearchResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.FilmSequelsAndPrequelsResponse module
+---------------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.FilmSequelsAndPrequelsResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.FiltersResponse module
+------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.FiltersResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.GeneralResponse module
+------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.GeneralResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.ImageResponse module
+----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.ImageResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.KinopoiskUserVoteResponse module
+----------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.KinopoiskUserVoteResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.MediaPostsResponse module
+---------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.MediaPostsResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.PersonByNameResponse module
+-----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.PersonByNameResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.PersonResponse module
+-----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.PersonResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.PersonResponseFilms module
+----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.PersonResponseFilms
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.PersonResponseSpouse module
+-----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.PersonResponseSpouse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.PremiereResponse module
+-------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.PremiereResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.RelatedFilmResponse module
+----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.RelatedFilmResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.ReviewResponse module
+-----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.ReviewResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.SeasonResponse module
+-----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.SeasonResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.StaffResponse module
+----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.StaffResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Responses.VideoResponse module
+----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Responses.VideoResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: NotKinoPoiskAPI.Responses
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/NotKinoPoiskAPI.Types.rst
+++ b/docs/source/NotKinoPoiskAPI.Types.rst
@@ -1,0 +1,245 @@
+NotKinoPoiskAPI.Types package
+=============================
+
+Submodules
+----------
+
+NotKinoPoiskAPI.Types.ApiKeyResponseDailyQuota module
+-----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.ApiKeyResponseDailyQuota
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.ApiKeyResponseTotalQuota module
+-----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.ApiKeyResponseTotalQuota
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Award module
+----------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Award
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.AwardPerson module
+----------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.AwardPerson
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.BoxOffice module
+--------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.BoxOffice
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Company module
+------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Company
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Country module
+------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Country
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.DigitalReleaseItem module
+-----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.DigitalReleaseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Distribution module
+-----------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Distribution
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Episode module
+------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Episode
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.ExternalSourceResponseItem module
+-------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.ExternalSourceResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Fact module
+---------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Fact
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Film module
+---------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Film
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.FilmCollectionResponseItem module
+-------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.FilmCollectionResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.FilmResponseFilm module
+---------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.FilmResponseFilm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.FilmSearchByFiltersResponseItem module
+------------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.FilmSearchByFiltersResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.FilmSearchResponseFilm module
+---------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.FilmSearchResponseFilm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.FiltersResponseCountry module
+---------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.FiltersResponseCountry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.FiltersResponseGenre module
+-------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.FiltersResponseGenre
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Genre module
+----------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Genre
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.ImageResponseItem module
+----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.ImageResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.KinopoiskUserVoteResponseItem module
+----------------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.KinopoiskUserVoteResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.MediaPostsResponseItem module
+---------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.MediaPostsResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.PersonByNameResponseItem module
+-----------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.PersonByNameResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.PremiereResponseItem module
+-------------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.PremiereResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.ProxyItem module
+--------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.ProxyItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.ReviewResponseItem module
+-----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.ReviewResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.Season module
+-----------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.Season
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+NotKinoPoiskAPI.Types.VideoResponseItem module
+----------------------------------------------
+
+.. automodule:: NotKinoPoiskAPI.Types.VideoResponseItem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: NotKinoPoiskAPI.Types
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/NotKinoPoiskAPI.rst
+++ b/docs/source/NotKinoPoiskAPI.rst
@@ -1,0 +1,23 @@
+NotKinoPoiskAPI package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   NotKinoPoiskAPI.Controller
+   NotKinoPoiskAPI.Data
+   NotKinoPoiskAPI.Enums
+   NotKinoPoiskAPI.Errors
+   NotKinoPoiskAPI.Responses
+   NotKinoPoiskAPI.Types
+
+Module contents
+---------------
+
+.. automodule:: NotKinoPoiskAPI
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,40 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+import os
+import sys
+from pathlib import Path
+
+abs_path = Path(__file__).parent.parent.parent.absolute()
+sys.path.insert(0, abs_path.__str__())
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'NotKinoPoiskAPI'
+copyright = '2024, Maxim Harder'
+author = 'Maxim Harder'
+release = '1.0.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+		'sphinx.ext.autodoc',
+		'sphinx.ext.viewcode',
+		'sphinx.ext.napoleon'
+]
+
+templates_path = ['_templates']
+exclude_patterns = [
+		'_build', 'Thumbs.db', '.DS_Store', '__pycache__', '.gitignore', 'changelog.md', 'env.default', 'LICENSE', 'make.bat', 'Makefile', 'manifest.json', 'pyproject.toml', 'requirements.txt', 'setup.py'
+]
+
+language = 'ru'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. NotKinoPoiskAPI documentation master file, created by
+   sphinx-quickstart on Sun May 26 11:41:20 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to NotKinoPoiskAPI's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+NotKinoPoiskAPI
+===============
+
+.. toctree::
+   :maxdepth: 4
+
+   NotKinoPoiskAPI

--- a/docs/tools/Makefile
+++ b/docs/tools/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = ../source
+BUILDDIR      = ../../build/docs
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/tools/make.bat
+++ b/docs/tools/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=..\source
+set BUILDDIR=..\..\build\docs
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/make_docs.cmd
+++ b/make_docs.cmd
@@ -1,0 +1,3 @@
+sphinx-apidoc -o docs\source .\NotKinoPoiskAPI\
+rem .\docs\tools\make.bat clean html
+.\docs\tools\make.bat html


### PR DESCRIPTION
Updated make_docs.cmd to include the sphinx-apidoc command to generate documentation
from the NotKinoPoiskAPI package. Removed unnecessary commands and streamlined the
process for building documentation efficiently.